### PR TITLE
Error when to run `cordova build ios --device` add to readme

### DIFF
--- a/cordova-angularjs/README.md
+++ b/cordova-angularjs/README.md
@@ -83,6 +83,8 @@ Go back to the Terminal window to build the Cordova app.
 ```
  $ cd cordova/ExampleCordovaAngular
  $ cordova build ios --device
+ or XCode 11.5
+ $ cordova build ios --device --buildFlag="-UseModernBuildSystem=0" 
 ```
 
 Go back to Xcode:

--- a/cordova-angularjs/README.md
+++ b/cordova-angularjs/README.md
@@ -68,7 +68,7 @@ Next, run a build to copy the NodeJs and AngularJs files to the `cordova/www` fo
 Open the Cordova app project in Xcode:
 
 ```
- $ open cordova/ExampleCordovaAngular/platforms/ios/HelloCordova.xcodeproj
+ $ open cordova/ExampleCordovaAngular/platforms/ios/HelloCordova.xcworkspace
 ```
 
 In Xcode:


### PR DESCRIPTION


Error when to run `cordova build ios --device` #13

https://github.com/JaneaSystems/nodejs-mobile-samples/issues/13#issuecomment-447251621


should  `open ./platforms/ios/HelloWorld.xcworkspace/`

https://cordova.apache.org/docs/en/latest/guide/platforms/ios/#deploying-to-simulator