### PR TITLE
Resolved the return type mismatch in android sample

### DIFF
--- a/android/native-gradle-node-folder/app/src/main/java/com/yourorg/sample/MainActivity.java
+++ b/android/native-gradle-node-folder/app/src/main/java/com/yourorg/sample/MainActivity.java
@@ -93,7 +93,7 @@ public class MainActivity extends AppCompatActivity {
      * A native method that is implemented by the 'native-lib' native library,
      * which is packaged with this application.
      */
-    public native Integer startNodeWithArguments(String[] arguments);
+    public native int startNodeWithArguments(String[] arguments);
 
     private boolean wasAPKUpdated() {
         SharedPreferences prefs = getApplicationContext().getSharedPreferences("NODEJS_MOBILE_PREFS", Context.MODE_PRIVATE);

--- a/android/native-gradle/app/src/main/java/com/yourorg/sample/MainActivity.java
+++ b/android/native-gradle/app/src/main/java/com/yourorg/sample/MainActivity.java
@@ -80,5 +80,5 @@ public class MainActivity extends AppCompatActivity {
      * A native method that is implemented by the 'native-lib' native library,
      * which is packaged with this application.
      */
-    public native Integer startNodeWithArguments(String[] arguments);
+    public native int startNodeWithArguments(String[] arguments);
 }


### PR DESCRIPTION
Issue #36
I have changed the `Integer` to an `int` in the `MainActivity.java` file of both the android sample projects. (without and with the nodejs folder)